### PR TITLE
feat: wire engine-rest minted-jwt + Graph auth into the MCP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ Regarding the MCP client configuration:
 }
 ```
 
+### Outgoing engine-rest authentication
+
+The two sections above secure the inbound hop (MCP client → MCP server). How the MCP
+server then authenticates its **outgoing** calls to engine-rest is controlled by
+`cibseven.mcp.engine-rest.auth` (provided by `common-mcp-auth`). The default,
+`passthrough`, forwards the validated bearer unchanged; `minted-jwt` instead mints a
+short-lived CIB seven JWT so the engine's (LDAP) identity provider stays authoritative.
+See the [REST API MCP plugin README](https://github.com/cibseven/cibseven-mcp-restapi#outgoing-engine-rest-authentication)
+for the full strategy, properties and deployment requirements.
+
+This example is configured for `minted-jwt` with the Graph-based resolver (Entra `oid` →
+`onPremisesSamAccountName`). The OAuth2 issuer and the `graph` client registration are
+read from the environment — for pure local development without Entra, comment out the
+`spring.security.oauth2` block in `application.yaml` and set
+`cibseven.mcp.engine-rest.auth: passthrough`.
+
 ### Example
 
 *We configure the server to be named as `cibseven-mcp`.*

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,11 +22,39 @@ spring:
         instructions: "CIB seven MCP server exposing the Engine REST API and business tools to execute CIB seven processes."
         streamable-http:
           mcp-endpoint: /mcp
+  # OAuth2: validate the inbound MCP bearer (resource server) and obtain an app-only
+  # Graph token (client registration 'graph', client_credentials) for the oid->sAMAccountName
+  # lookup. Values come from the environment — do NOT commit tenant ids / secrets (task G.17).
+  # Setting issuer-uri activates CommonMcpOAuth2Configuration; for pure local dev without
+  # Entra, comment this block out and set cibseven.mcp.engine-rest.auth=passthrough.
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${ENTRA_ISSUER_URI}        # https://login.microsoftonline.com/<tenant-id>/v2.0
+      client:
+        registration:
+          graph:
+            client-id: ${GRAPH_CLIENT_ID}
+            client-secret: ${GRAPH_CLIENT_SECRET}
+            authorization-grant-type: client_credentials
+            scope: https://graph.microsoft.com/.default
+            provider: entra
+        provider:
+          entra:
+            token-uri: ${ENTRA_TOKEN_URI}        # https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token
 
 cibseven:
   mcp:
     process-mcp: true
     restapi-mcp: true
+    # Engine-rest auth strategy (common-mcp-auth). minted-jwt: translate the validated
+    # Entra identity into a short-lived CIB seven HMAC JWT; resolver=graph maps the Entra
+    # oid -> onPremisesSamAccountName via Microsoft Graph (LDAP-prod path, tasks D.8/D.9).
+    engine-rest:
+      auth: minted-jwt
+      minted-jwt:
+        resolver: graph
   webclient:
     services:
       basePath: services/v1


### PR DESCRIPTION
## Summary

Configures the get-started MCP server example for the decided LDAP-prod outbound-auth path, exercising the `common-mcp-auth` strategy end-to-end.

## Changes

- **`application.yaml`**: `cibseven.mcp.engine-rest.auth=minted-jwt` + `minted-jwt.resolver=graph`; `spring.security.oauth2` resource-server `issuer-uri` and a `graph` client registration (`client_credentials`, scope `…/.default`). All sensitive values are `${ENV}` placeholders — no tenant ids / secrets committed.
- **README**: "Outgoing engine-rest authentication" pointer to the REST API MCP plugin docs, plus the local-dev fallback (comment out the `spring.security.oauth2` block and set `auth=passthrough`).

## Notes

- Targets the `cibseven-mcp-servers` branch.
- With `issuer-uri` set, the app expects the Entra env vars at startup (by design for a secured config); the README documents the passthrough fallback for pure local dev.
- Requires the companion `common-mcp-auth` and `cibseven-mcp-restapi` PRs.
- Context / rationale: CIB7-1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)